### PR TITLE
Fix choice of device and allow use of GPU

### DIFF
--- a/trame_mnist/app/engine/ml/common.py
+++ b/trame_mnist/app/engine/ml/common.py
@@ -24,6 +24,7 @@ DEVICE = torch.device("cpu")
 
 
 def update_ml_device(cpu_only=True):
+    global DEVICE
     if not cpu_only and torch.cuda.is_available():
         DEVICE = torch.device("cuda")
         print(" ~~~ Using GPU ~~~ \n")


### PR DESCRIPTION
@jourdain Made a similar change here to make `DEVICE` a global variable, but I noticed that the returned model in the `training_add()` function still uses CPU. This may be because it is spawned in a separate process?