### PR TITLE
Update README and setup.cfg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,6 @@ venv setup for AI
 
     conda create --name trame-mnist python=3.9
     conda activate trame-mnist
-    conda install "pytorch==1.9.1" "torchvision==0.10.1" -c pytorch
-    conda install scipy "scikit-learn==0.24.2" "scikit-image==0.18.3" -c conda-forge
 
     # For development when inside repo
     pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,19 +27,19 @@ keywords =
 packages = find:
 include_package_data = True
 install_requires =
-    trame>=2.0.0rc2
+    trame>=2.1.0
     # chart
     altair==4.1.0
     # ml core
-    torch>=1.9.1
-    torchvision>=0.10.0,<=0.10.1
+    torch==1.10.0
+    torchvision==0.11.1
     # xaitk
     smqtk-classifier==0.19.0
     smqtk-core==0.18.1
     smqtk-dataprovider==0.16.0
     smqtk-descriptors==0.18.1
     smqtk-image-io==0.16.2
-    xaitk-saliency==0.4.0
+    xaitk-saliency==0.6.1
     scikit-learn==0.24.2
     scikit-image==0.18.3
 


### PR DESCRIPTION
This PR updates the README installation instructions to use a simpler `pip`-only install, which avoids potential package clashes with `conda` and `pip` installs (as was previously observed with `scipy` on Ubuntu 20.04). This also updates the `setup.cfg` file with newer versions of dependencies, including the latest version of `xaitk-saliency` (v0.6.1).

Given the new `pip` install instructions, it may also make sense to update the corresponding pypi package (if needed) for users who do not perform an editable install.